### PR TITLE
Rebase on upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - linux
 sudo: required
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck
   - go get -d ./...
 script:

--- a/README.md
+++ b/README.md
@@ -10,4 +10,19 @@ For more information on taskstats, please see:
   - https://www.kernel.org/doc/Documentation/accounting/taskstats-struct.txt
   - https://andrestc.com/post/linux-delay-accounting/
 
+Notes
+-----
+* When instrumenting Go programs, use either the `taskstats.Self()` or
+  `taskstats.TGID()` method.  Using the `PID()` method on multithreaded
+  programs, including Go programs, will produce inaccurate results.
+
+* Access to taskstats requires that the application have at least `CAP_NET_RAW`
+  capability (see
+  [capabilities(7)](http://man7.org/linux/man-pages/man7/capabilities.7.html)).
+  Otherwise, the application must be run as root.
+
+* If running the application in a container (e.g. via Docker), it cannot be run
+  in a network namespace -- usually this means that host networking must be
+  used.
+
 MIT Licensed.

--- a/client.go
+++ b/client.go
@@ -44,12 +44,17 @@ func (c *Client) CGroupStats(path string) (*CGroupStats, error) {
 // Self is a convenience method for retrieving statistics about the current
 // process.
 func (c *Client) Self() (*Stats, error) {
-	return c.c.PID(os.Getpid())
+	return c.c.TGID(os.Getpid())
 }
 
 // PID retrieves statistics about a process, identified by its PID.
 func (c *Client) PID(pid int) (*Stats, error) {
 	return c.c.PID(pid)
+}
+
+// TGID retrieves statistics about a thread group, identified by its TGID.
+func (c *Client) TGID(tgid int) (*Stats, error) {
+	return c.c.TGID(tgid)
 }
 
 // Close releases resources used by a Client.
@@ -62,4 +67,5 @@ type osClient interface {
 	io.Closer
 	CGroupStats(path string) (*CGroupStats, error)
 	PID(pid int) (*Stats, error)
+	TGID(tgid int) (*Stats, error)
 }

--- a/client_linux.go
+++ b/client_linux.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// sizeofTaskstats is the size of a unix.Taskstats structure.
-	sizeofTaskstats   = int(unsafe.Sizeof(unix.Taskstats{}))
+	// sizeofTaskstatsV8 is the size of a unix.Taskstats structure as of
+	// taskstats version 8.
+	sizeofTaskstatsV8 = int(unsafe.Offsetof(unix.Taskstats{}.Thrashing_count))
 	sizeofCGroupStats = int(unsafe.Sizeof(unix.CGroupStats{}))
 )
 
@@ -194,7 +195,7 @@ func parseMessage(m genetlink.Message, typeAggr uint16) (*Stats, error) {
 			// Verify that the byte slice containing a unix.Taskstats is the
 			// size expected by this package, so we don't blindly cast the
 			// byte slice into a structure of the wrong size.
-			if want, got := sizeofTaskstats, len(na.Data); want != got {
+			if want, got := sizeofTaskstatsV8, len(na.Data); want != got {
 				return nil, fmt.Errorf("unexpected taskstats structure size, want %d, got %d", want, got)
 			}
 

--- a/client_linux.go
+++ b/client_linux.go
@@ -59,10 +59,19 @@ func (c *client) Close() error {
 
 // PID implements osClient.
 func (c *client) PID(pid int) (*Stats, error) {
-	// Query taskstats for information using a specific PID.
+	return c.getStats(pid, unix.TASKSTATS_CMD_ATTR_PID, unix.TASKSTATS_TYPE_AGGR_PID)
+}
+
+// TGID implements osClient.
+func (c *client) TGID(tgid int) (*Stats, error) {
+	return c.getStats(tgid, unix.TASKSTATS_CMD_ATTR_TGID, unix.TASKSTATS_TYPE_AGGR_TGID)
+}
+
+func (c *client) getStats(id int, cmdAttr, typeAggr uint16) (*Stats, error) {
+	// Query taskstats for information using a specific ID.
 	attrb, err := netlink.MarshalAttributes([]netlink.Attribute{{
-		Type: unix.TASKSTATS_CMD_ATTR_PID,
-		Data: nlenc.Uint32Bytes(uint32(pid)),
+		Type: cmdAttr,
+		Data: nlenc.Uint32Bytes(uint32(id)),
 	}})
 	if err != nil {
 		return nil, err
@@ -87,7 +96,7 @@ func (c *client) PID(pid int) (*Stats, error) {
 		return nil, fmt.Errorf("unexpected number of taskstats messages: %d", l)
 	}
 
-	return parseMessage(msgs[0])
+	return parseMessage(msgs[0], typeAggr)
 }
 
 // CGroupStats implements osClient.
@@ -159,15 +168,15 @@ func parseCGroupMessage(m genetlink.Message) (*CGroupStats, error) {
 }
 
 // parseMessage attempts to parse a Stats structure from a generic netlink message.
-func parseMessage(m genetlink.Message) (*Stats, error) {
+func parseMessage(m genetlink.Message, typeAggr uint16) (*Stats, error) {
 	attrs, err := netlink.UnmarshalAttributes(m.Data)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, a := range attrs {
-		// Only parse PID+stats structure.
-		if a.Type != unix.TASKSTATS_TYPE_AGGR_PID {
+		// Only parse ID+stats structure.
+		if a.Type != typeAggr {
 			continue
 		}
 
@@ -177,7 +186,7 @@ func parseMessage(m genetlink.Message) (*Stats, error) {
 		}
 
 		for _, na := range nattrs {
-			// Only parse Stats element since caller would already have PID.
+			// Only parse Stats element since caller would already have ID.
 			if na.Type != unix.TASKSTATS_TYPE_STATS {
 				continue
 			}

--- a/client_linux.go
+++ b/client_linux.go
@@ -89,9 +89,7 @@ func (c *client) getStats(id int, cmdAttr, typeAggr uint16) (*Stats, error) {
 		Data: attrb,
 	}
 
-	flags := netlink.HeaderFlagsRequest
-
-	msgs, err := c.c.Execute(msg, c.family.ID, flags)
+	msgs, err := c.c.Execute(msg, c.family.ID, netlink.Request)
 	if err != nil {
 		return nil, err
 	}
@@ -129,9 +127,7 @@ func (c *client) CGroupStats(path string) (*CGroupStats, error) {
 		Data: attrb,
 	}
 
-	flags := netlink.HeaderFlagsRequest
-
-	msgs, err := c.c.Execute(msg, c.family.ID, flags)
+	msgs, err := c.c.Execute(msg, c.family.ID, netlink.Request)
 	if err != nil {
 		return nil, err
 	}

--- a/client_linux.go
+++ b/client_linux.go
@@ -17,6 +17,9 @@ const (
 	// sizeofTaskstatsV8 is the size of a unix.Taskstats structure as of
 	// taskstats version 8.
 	sizeofTaskstatsV8 = int(unsafe.Offsetof(unix.Taskstats{}.Thrashing_count))
+	// sizeofTaskstatsV9 is the size of a unix.Taskstats structure as of
+	// taskstats version 9.
+	sizeofTaskstatsV9 = int(unsafe.Sizeof(unix.Taskstats{}))
 	sizeofCGroupStats = int(unsafe.Sizeof(unix.CGroupStats{}))
 )
 
@@ -195,8 +198,8 @@ func parseMessage(m genetlink.Message, typeAggr uint16) (*Stats, error) {
 			// Verify that the byte slice containing a unix.Taskstats is the
 			// size expected by this package, so we don't blindly cast the
 			// byte slice into a structure of the wrong size.
-			if want, got := sizeofTaskstatsV8, len(na.Data); want != got {
-				return nil, fmt.Errorf("unexpected taskstats structure size, want %d, got %d", want, got)
+			if wantV8, wantV9, got := sizeofTaskstatsV8, sizeofTaskstatsV9, len(na.Data); wantV8 != got && wantV9 != got {
+				return nil, fmt.Errorf("unexpected taskstats structure size, want %d (v8) or %d (v9), got %d", wantV8, wantV9, got)
 			}
 
 			return parseStats(*(*unix.Taskstats)(unsafe.Pointer(&na.Data[0])))

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -377,7 +377,7 @@ func TestLinuxClientPIDOK(t *testing.T) {
 
 	fn := func(_ genetlink.Message, _ netlink.Message) ([]genetlink.Message, error) {
 		// Cast unix.Taskstats structure into a byte array with the correct size.
-		b := *(*[sizeofTaskstats]byte)(unsafe.Pointer(&stats))
+		b := *(*[sizeofTaskstatsV8]byte)(unsafe.Pointer(&stats))
 
 		return []genetlink.Message{{
 			Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
@@ -453,7 +453,7 @@ func TestLinuxClientTGIDOK(t *testing.T) {
 
 	fn := func(_ genetlink.Message, _ netlink.Message) ([]genetlink.Message, error) {
 		// Cast unix.Taskstats structure into a byte array with the correct size.
-		b := *(*[sizeofTaskstats]byte)(unsafe.Pointer(&stats))
+		b := *(*[sizeofTaskstatsV8]byte)(unsafe.Pointer(&stats))
 
 		return []genetlink.Message{{
 			Data: nltest.MustMarshalAttributes([]netlink.Attribute{{

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -159,7 +159,7 @@ func TestLinuxClientCGroupStatsOK(t *testing.T) {
 	c := testClient(t, genltest.CheckRequest(
 		familyID,
 		unix.CGROUPSTATS_CMD_GET,
-		netlink.HeaderFlagsRequest,
+		netlink.Request,
 		fn,
 	))
 	defer c.Close()
@@ -393,7 +393,7 @@ func TestLinuxClientPIDOK(t *testing.T) {
 	c := testClient(t, genltest.CheckRequest(
 		familyID,
 		unix.TASKSTATS_CMD_GET,
-		netlink.HeaderFlagsRequest,
+		netlink.Request,
 		fn,
 	))
 	defer c.Close()
@@ -469,7 +469,7 @@ func TestLinuxClientTGIDOK(t *testing.T) {
 	c := testClient(t, genltest.CheckRequest(
 		familyID,
 		unix.TASKSTATS_CMD_GET,
-		netlink.HeaderFlagsRequest,
+		netlink.Request,
 		fn,
 	))
 	defer c.Close()

--- a/client_others.go
+++ b/client_others.go
@@ -38,3 +38,8 @@ func (c *client) CGroupStats(path string) (*CGroupStats, error) {
 func (c *client) PID(pid int) (*Stats, error) {
 	return nil, errUnimplemented
 }
+
+// TGID implements osClient.
+func (c *client) TGID(tgid int) (*Stats, error) {
+	return nil, errUnimplemented
+}


### PR DESCRIPTION
Changes were made upstream to support some backwards incompatibility things in [mdlayher/netlink](https://github.com/mdlayher/netlink). Specifically, [this change](https://github.com/mdlayher/netlink/commit/080e8e36878e0f73c5a28fb285527eefe3603390), renames some constants which breaks things.